### PR TITLE
Update SpecialUserScore_body.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ Version 2.2 2016-01-25 (Lojjik Braughler)
 Version 2.3 2017-03-30 (Nic Jansma)
 
 * Works with `$wgMiserMode` enabled
+
+Version 2.3 2020-12-21 (Clint L. Johnson)
+
+* Updated SQL Query to work with [Actor Migration](https://www.mediawiki.org/wiki/Actor_migration) in MediaWiki 1.35.1
+
+

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Version 2.3 2017-03-30 (Nic Jansma)
 
 * Works with `$wgMiserMode` enabled
 
-Version 2.3 2020-12-21 (Clint L. Johnson)
+Version 2.4 2020-12-21 (Clint L. Johnson)
 
 * Updated SQL Query to work with [Actor Migration](https://www.mediawiki.org/wiki/Actor_migration) in MediaWiki 1.35.1
 

--- a/SpecialUserScore_body.php
+++ b/SpecialUserScore_body.php
@@ -29,15 +29,16 @@ class SpecialUserScore extends QueryPage {
 
 	function getQueryInfo() {
 		return array (
-			'tables' => array ( 'user', 'revision', 'page' ),
+			'tables' => array ( 'actor', 'revision', 'page', 'revision_actor_temp' ),
 			'fields' => array ( 'COUNT(rev_id) as value',
-								'COUNT(DISTINCT rev_page) as page_value',
-								'user_name as title',
-								NS_USER . ' as namespace' ),
-			'conds' => array ( 'user_id = rev_user',
-								'page_id = rev_page',
-								'page_namespace = 0' ),
-			'options' => array( 'GROUP BY' => 'user_name' )
+					    'COUNT(DISTINCT rev_page) as page_value',
+					    'actor_name as title',
+					    NS_USER . ' as namespace' ),
+			'conds' => array ( 'revactor_rev = rev_id',
+					   'actor_id = revactor_actor',
+					   'page_id = rev_page',
+					   'page_namespace = 0' ),
+			'options' => array( 'GROUP BY' => 'actor_name' )
 		);
 	}
 


### PR DESCRIPTION
Modified SQL Query to deal with schema modification introduced in MediaWiki 1.31 which created a temporary table for managing revisions.  This modification is tested with MediaWiki 1.35.1 but will break when the Actor migration is complete in a future build and the table revision_actor_temp is merged back to the revision table as described in [Actor migration](https://www.mediawiki.org/wiki/Actor_migration)