### PR TITLE
v2.5: Compatibility with MW v1.39 Actor Migration completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ Version 2.3 2017-03-30 (Nic Jansma)
 Version 2.4 2020-12-21 (Clint L. Johnson)
 
 * Updated SQL Query to work with [Actor Migration](https://www.mediawiki.org/wiki/Actor_migration) in MediaWiki 1.35.1
+
+Version 2.5 2025-04-23 (Nic Jansma)
+
+* Updated SQL Query to work with the final stage of the [Actor Migration](https://www.mediawiki.org/wiki/Actor_migration) that removed the `revision_actor_temp` table in MediaWiki 1.39+

--- a/SpecialUserScore_body.php
+++ b/SpecialUserScore_body.php
@@ -29,13 +29,12 @@ class SpecialUserScore extends QueryPage {
 
 	function getQueryInfo() {
 		return array (
-			'tables' => array ( 'actor', 'revision', 'page', 'revision_actor_temp' ),
+			'tables' => array ( 'actor', 'revision', 'page' ),
 			'fields' => array ( 'COUNT(rev_id) as value',
 					    'COUNT(DISTINCT rev_page) as page_value',
 					    'actor_name as title',
 					    NS_USER . ' as namespace' ),
-			'conds' => array ( 'revactor_rev = rev_id',
-					   'actor_id = revactor_actor',
+			'conds' => array ( 'actor_id = rev_actor',
 					   'page_id = rev_page',
 					   'page_namespace = 0' ),
 			'options' => array( 'GROUP BY' => 'actor_name' )

--- a/extension.json
+++ b/extension.json
@@ -6,11 +6,11 @@
 		"Lojjik Braughler"
 	],
 	"url": "https://www.mediawiki.org/wiki/Extension:SpecialUserScore",
-	"version": "2.4",
+	"version": "2.5",
 	"descriptionmsg": "userscore-desc",
 	"license-name": "GPL-2.0+",
 	"requires": {
-		"MediaWiki": ">= 1.25.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 	"AutoloadClasses": {
 		"SpecialUserScore": "SpecialUserScore_body.php"


### PR DESCRIPTION
Changes query to remove use of `revision_actor_temp` table that was removed in MW 1.39+ as part of the [actor migration](https://www.mediawiki.org/wiki/Actor_migration).

Resolves https://github.com/nicjansma/mediawiki-Extension-SpecialUserScore/issues/5